### PR TITLE
ysl: Remove duplicated qseecom HAL entry

### DIFF
--- a/manifest.xml
+++ b/manifest.xml
@@ -484,16 +484,6 @@ IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
             <instance>default</instance>
         </interface>
     </hal>
-    <!-- QSEECom HAL service -->
-    <hal format="hidl">
-        <name>vendor.qti.hardware.qseecom</name>
-        <transport>hwbinder</transport>
-        <version>1.0</version>
-        <interface>
-            <name>IQSEECom</name>
-            <instance>default</instance>
-        </interface>
-    </hal>
     <hal format="hidl">
         <name>vendor.qti.hardware.radio.am</name>
         <transport>hwbinder</transport>


### PR DESCRIPTION
This (vendor.qti.hardware.qseecom) entry was accidentally duplicated on previous commit ( https://github.com/lostark13/android_device_xiaomi_ysl/commit/9f8aa7c8acaf39e405ff0c67bf9ee7e9ec81c39d )